### PR TITLE
add option for username stripping

### DIFF
--- a/src/greeterconfiguration.h
+++ b/src/greeterconfiguration.h
@@ -38,6 +38,7 @@
 #define CONFIG_KEY_KEYBOARD_POSITION    "keyboard-position"
 #define CONFIG_KEY_A11Y_STATES          "a11y-states"
 #define CONFIG_KEY_AT_SPI_ENABLED       "at-spi-enabled"
+#define CONFIG_KEY_USERNAME_STRIP_WS    "username-strip-whitespace"
 
 #define CONFIG_GROUP_MONITOR            "monitor:"
 #define CONFIG_KEY_BACKGROUND           "background"

--- a/src/greeterconfiguration.h
+++ b/src/greeterconfiguration.h
@@ -38,7 +38,6 @@
 #define CONFIG_KEY_KEYBOARD_POSITION    "keyboard-position"
 #define CONFIG_KEY_A11Y_STATES          "a11y-states"
 #define CONFIG_KEY_AT_SPI_ENABLED       "at-spi-enabled"
-#define CONFIG_KEY_USERNAME_STRIP_WS    "username-strip-whitespace"
 
 #define CONFIG_GROUP_MONITOR            "monitor:"
 #define CONFIG_KEY_BACKGROUND           "background"

--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -95,6 +95,7 @@ static GtkEntry     *username_entry, *password_entry;
 static GtkLabel     *message_label;
 static GtkInfoBar   *info_bar;
 static GtkButton    *cancel_button, *login_button;
+static gboolean     username_strip_whitespace = FALSE;
 
 /* Panel */
 static GtkWidget    *panel_window, *menubar;
@@ -2295,6 +2296,17 @@ G_MODULE_EXPORT
 gboolean
 username_focus_out_cb (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
+    if (username_strip_whitespace == TRUE)
+    {
+	const gchar *username = gtk_entry_get_text (username_entry);
+	gchar *stripped_username = g_strdup (username);
+
+	g_strstrip (stripped_username);
+	if (g_strcmp0 (username, stripped_username) != 0)
+	    gtk_entry_set_text (username_entry, stripped_username);
+	g_free (stripped_username);
+    }
+
     if (!g_strcmp0(gtk_entry_get_text (username_entry), "") == 0)
         start_authentication (gtk_entry_get_text (username_entry));
     return FALSE;
@@ -3073,6 +3085,13 @@ main (int argc, char **argv)
     message_label = GTK_LABEL (gtk_builder_get_object (builder, "message_label"));
     cancel_button = GTK_BUTTON (gtk_builder_get_object (builder, "cancel_button"));
     login_button = GTK_BUTTON (gtk_builder_get_object (builder, "login_button"));
+
+    value = config_get_string (NULL, CONFIG_KEY_USERNAME_STRIP_WS, NULL);
+    if (value)
+    {
+	if (g_strcmp0 (value, "true") == 0)
+	    username_strip_whitespace = TRUE;
+    }
 
     /* Panel window*/
     panel_window = GTK_WIDGET (gtk_builder_get_object (builder, "panel_window"));

--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -95,7 +95,6 @@ static GtkEntry     *username_entry, *password_entry;
 static GtkLabel     *message_label;
 static GtkInfoBar   *info_bar;
 static GtkButton    *cancel_button, *login_button;
-static gboolean     username_strip_whitespace = FALSE;
 
 /* Panel */
 static GtkWidget    *panel_window, *menubar;
@@ -2296,16 +2295,13 @@ G_MODULE_EXPORT
 gboolean
 username_focus_out_cb (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
-    if (username_strip_whitespace == TRUE)
-    {
-	const gchar *username = gtk_entry_get_text (username_entry);
-	gchar *stripped_username = g_strdup (username);
+    const gchar *username = gtk_entry_get_text (username_entry);
+    gchar *stripped_username = g_strdup (username);
 
-	g_strstrip (stripped_username);
-	if (g_strcmp0 (username, stripped_username) != 0)
-	    gtk_entry_set_text (username_entry, stripped_username);
-	g_free (stripped_username);
-    }
+    g_strstrip (stripped_username);
+    if (g_strcmp0 (username, stripped_username) != 0)
+	gtk_entry_set_text (username_entry, stripped_username);
+    g_free (stripped_username);
 
     if (!g_strcmp0(gtk_entry_get_text (username_entry), "") == 0)
         start_authentication (gtk_entry_get_text (username_entry));
@@ -3085,13 +3081,6 @@ main (int argc, char **argv)
     message_label = GTK_LABEL (gtk_builder_get_object (builder, "message_label"));
     cancel_button = GTK_BUTTON (gtk_builder_get_object (builder, "cancel_button"));
     login_button = GTK_BUTTON (gtk_builder_get_object (builder, "login_button"));
-
-    value = config_get_string (NULL, CONFIG_KEY_USERNAME_STRIP_WS, NULL);
-    if (value)
-    {
-	if (g_strcmp0 (value, "true") == 0)
-	    username_strip_whitespace = TRUE;
-    }
 
     /* Panel window*/
     panel_window = GTK_WIDGET (gtk_builder_get_object (builder, "panel_window"));

--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -2300,7 +2300,7 @@ username_focus_out_cb (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 
     g_strstrip (stripped_username);
     if (g_strcmp0 (username, stripped_username) != 0)
-	gtk_entry_set_text (username_entry, stripped_username);
+        gtk_entry_set_text (username_entry, stripped_username);
     g_free (stripped_username);
 
     if (!g_strcmp0(gtk_entry_get_text (username_entry), "") == 0)


### PR DESCRIPTION
Many people use space to wakeup display from screensaver, so it happens that they end up having one space in front of their username in greeter.  They will then get an incorrect password message even and trying it again won't help, because they only reenter their password instead of double checking the username. One leading space is hard to spot, since the password field at least looks to have more space before the first circle.

This pull request adds a config option `username-strip-whitespace`.