### PR TITLE
Adding a usage example to the greeter config

### DIFF
--- a/data/lightdm-gtk-greeter.conf
+++ b/data/lightdm-gtk-greeter.conf
@@ -1,5 +1,8 @@
 # LightDM GTK+ Configuration
 # Available configuration options listed below.
+# Please list the configuration options that you want to use after [greeter] without the # for example:
+# [greeter]
+# example-option=example-value
 #
 # Appearance:
 #  theme-name = GTK+ theme to use


### PR DESCRIPTION
So... I added an example on how to use the config file.

Because god knows how long I had to search the internet to find this information. I had to go into distro lightdm-gtk-greeter.conf(s) to find how to use it since I could not find forum questions or documentation about the lightdm-gtk-greeter.conf file. 