### PR TITLE
support configuring the keyboard layouts of the ~layout indicator

### DIFF
--- a/data/lightdm-gtk-greeter.conf
+++ b/data/lightdm-gtk-greeter.conf
@@ -32,7 +32,8 @@
 # Panel:
 #  panel-position = top|bottom ("top" by default)
 #  clock-format = strftime-format string, e.g. %H:%M
-#  indicators = semi-colon ";" separated list of allowed indicator modules. Built-in indicators include "~a11y", "~language", "~session", "~power", "~clock", "~host", "~spacer". Unity indicators can be represented by short name (e.g. "sound", "power"), service file name, or absolute path
+#  indicators = semi-colon ";" separated list of allowed indicator modules. Built-in indicators include "~a11y", "~language", "~session", "~power", "~clock", "~host", "~spacer", "~layout". Unity indicators can be represented by short name (e.g. "sound", "power"), service file name, or absolute path
+#  keyboard-layouts = semi-colon ";" separated list keyboard layouts to be listed by the "~layout" indicator (empty by default which provides all available layouts)
 #
 # Accessibility:
 #  a11y-states = states of accessibility features: "name" - save state on exit, "-name" - disabled at start (default value for unlisted), "+name" - enabled at start. Allowed names: contrast, font, keyboard, reader.

--- a/src/greeterconfiguration.h
+++ b/src/greeterconfiguration.h
@@ -32,6 +32,7 @@
 #define CONFIG_KEY_ROUND_USER_IMAGE     "round-user-image"
 #define CONFIG_KEY_HIGHLIGHT_LOGGED_USER "highlight-logged-user"
 #define CONFIG_KEY_KEYBOARD             "keyboard"
+#define CONFIG_KEY_KEYBOARD_LAYOUTS     "keyboard-layouts"
 #define CONFIG_KEY_READER               "reader"
 #define CONFIG_KEY_CLOCK_FORMAT         "clock-format"
 #define CONFIG_KEY_ACTIVE_MONITOR       "active-monitor"


### PR DESCRIPTION
The new `keyboard-layouts` configuration option will filter the list of keyboard layouts shown by the `~layout`  indicator to those selected therein (semicolon separated list). 

Example:
```
keyboard-layouts=us;de;ch
```

will provide
- English (US)
- German
- German (Switzerland)

Tested on RHEL 8.
Implements #63 