### PR TITLE
allow to configure a default session manager

### DIFF
--- a/data/lightdm-gtk-greeter.conf
+++ b/data/lightdm-gtk-greeter.conf
@@ -45,6 +45,9 @@
 #  allow-debugging = false|true ("false" by default)
 #  screensaver-timeout = Timeout (in seconds) until the screen blanks when the greeter is called as lockscreen
 #
+# Session:
+#  default-session = session manager to be started when none has been selected by the user and no one is set as last used (unset by default)
+#
 # Template for per-monitor configuration:
 #  [monitor: name]
 #  background = overrides default value

--- a/src/greeterconfiguration.h
+++ b/src/greeterconfiguration.h
@@ -16,6 +16,7 @@
 
 #define CONFIG_GROUP_DEFAULT            "greeter"
 #define CONFIG_KEY_INDICATORS           "indicators"
+#define CONFIG_KEY_DEFAULT_SESSION      "default-session"
 #define CONFIG_KEY_DEBUGGING            "allow-debugging"
 #define CONFIG_KEY_SCREENSAVER_TIMEOUT  "screensaver-timeout"
 #define CONFIG_KEY_THEME                "theme-name"


### PR DESCRIPTION
I did not manage to get the default session set by `lightdm` as provided by RHEL 8 EPEL. 
I tried `user-session=gnome-xorg` and always ended up with following debug message stating that the `default-session` shall be `default`:
```
DEBUG-Message: 14:51:49.287: Connected api=1 version=1.30.0 default-session=default show-manual-login=false hide-users=true has-guest-account=false show-remote-login=true
```

Thus I now made it configurable on the `lightdm-gtk-greeter` side with a `default-session`  configuration key.
