### PR TITLE
Add config option to auto-start session with PAM

### DIFF
--- a/data/lightdm-gtk-greeter.conf
+++ b/data/lightdm-gtk-greeter.conf
@@ -28,6 +28,7 @@
 #  hide-user-image = false|true ("false" by default)
 #  round-user-image = false|true ("true" by default)
 #  highlight-logged-user  = false|true ("true" by default)
+#  pam-autologin = false|true ("false" by default) Whether the currently selected user should be logged in automatically, once a PAM auth succeeds.
 #
 # Panel:
 #  panel-position = top|bottom ("top" by default)

--- a/src/greeterconfiguration.h
+++ b/src/greeterconfiguration.h
@@ -32,6 +32,7 @@
 #define CONFIG_KEY_DEFAULT_USER_IMAGE   "default-user-image"
 #define CONFIG_KEY_ROUND_USER_IMAGE     "round-user-image"
 #define CONFIG_KEY_HIGHLIGHT_LOGGED_USER "highlight-logged-user"
+#define CONFIG_KEY_PAM_AUTOLOGIN        "pam-autologin"
 #define CONFIG_KEY_KEYBOARD             "keyboard"
 #define CONFIG_KEY_KEYBOARD_LAYOUTS     "keyboard-layouts"
 #define CONFIG_KEY_READER               "reader"

--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -2622,12 +2622,16 @@ authentication_complete_cb (LightDMGreeter *ldm)
 
     if (lightdm_greeter_get_is_authenticated (ldm))
     {
-        if (prompted)
+        if (config_get_bool (NULL, CONFIG_KEY_PAM_AUTOLOGIN, FALSE)) {
             start_session ();
-        else
-        {
-            gtk_widget_hide (GTK_WIDGET (password_entry));
-            gtk_widget_grab_focus (GTK_WIDGET (user_combo));
+        } else {
+            if (prompted)
+                start_session ();
+            else
+            {
+                gtk_widget_hide (GTK_WIDGET (password_entry));
+                gtk_widget_grab_focus (GTK_WIDGET (user_combo));
+            }
         }
     }
     else


### PR DESCRIPTION
[This PR continues #107. All changes are now in a single commit, for easier review and merge.]

This allows the user to choose whether to login automatically once PAM succeeds for the selected user.

On one hand, automatic login makes using fingerprint login more pleasant -- the user does not need to also press the "Log In" button, once the fingerprint is recognized.

On the other hand, using different PAM methods, autologin might be undesirable, as scrolling through the list of users might login a selected user when it is undesired.

For this reason, having this functionality as a user-configurable setting makes sense.