### PR TITLE
Fix off-centered hostname

### DIFF
--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -112,8 +112,7 @@ static GtkButton    *power_ok_button, *power_cancel_button;
 static GtkLabel     *power_title, *power_text;
 static GtkImage     *power_icon;
 
-static const gchar *DEFAULT_LAYOUT[] = {"~spacer", "~host", "~spacer", "~session",
-                                        "~a11y", "~clock", "~power", NULL};
+static const gchar *DEFAULT_LAYOUT[] = {"~host", "~spacer", "~session", "~a11y", "~clock", "~power", NULL};
 
 static const gchar *POWER_WINDOW_DATA_LOOP = "power-window-loop";           /* <GMainLoop*> */
 static const gchar *POWER_WINDOW_DATA_RESPONSE = "power-window-response";   /* <GtkResponseType> */

--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -112,8 +112,8 @@ static GtkButton    *power_ok_button, *power_cancel_button;
 static GtkLabel     *power_title, *power_text;
 static GtkImage     *power_icon;
 
-static const gchar *DEFAULT_LAYOUT[] = {"~spacer", "~spacer", "~host", "~spacer",
-                                        "~session", "~a11y", "~clock", "~power", NULL};
+static const gchar *DEFAULT_LAYOUT[] = {"~spacer", "~host", "~spacer", "~session",
+                                        "~a11y", "~clock", "~power", NULL};
 
 static const gchar *POWER_WINDOW_DATA_LOOP = "power-window-loop";           /* <GMainLoop*> */
 static const gchar *POWER_WINDOW_DATA_RESPONSE = "power-window-response";   /* <GtkResponseType> */


### PR DESCRIPTION
Resolves #85

Removes the duplicate spacer from the left side of the hostname in the default panel configuration so it centers properly.

I'm not a C developer and didn't test my changes, but this is just a hotfix, so it should probably be fine.