### PR TITLE
Fix display of PAM errors

### DIFF
--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -2636,7 +2636,7 @@ authentication_complete_cb (LightDMGreeter *ldm)
          * The error message probably comes from the PAM module that has a better knowledge
          * of the failure. */
         gboolean have_pam_error = !message_label_is_empty () &&
-                                  gtk_info_bar_get_message_type (info_bar) != GTK_MESSAGE_ERROR;
+                                  gtk_info_bar_get_message_type (info_bar) == GTK_MESSAGE_ERROR;
         if (prompted)
         {
             if (!have_pam_error)


### PR DESCRIPTION
Currently, PAM errors are not visible, being replaced by a generic "Your password is incorrect" or "Failed to authenticate" message. Conversely, there is _no_ error message printed if a non-error PAM message has previously been logged.

Both of these are the result of part of the `have_pam_error` test being backwards.