### PR TITLE
po: Add Georgian translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -33,6 +33,7 @@ id
 is
 it
 ja
+ka
 kk
 km
 ko


### PR DESCRIPTION
Hello,
Georgian translation (po/ka.po) is present, but not enabled, so it's not picked up/packaged by distros.
Enabling it.

BR, Ekaterine