### PR TITLE
Add password reveal toggle to the password entry

### DIFF
--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -2227,6 +2227,7 @@ cancel_authentication (void)
 
     /* Make sure password entry is back to normal */
     gtk_entry_set_visibility (password_entry, FALSE);
+    gtk_entry_set_icon_from_icon_name (password_entry, GTK_ENTRY_ICON_SECONDARY, "eye-open-negative-filled-symbolic");
 
     /* Force refreshing the prompt_box for "Other" */
     model = gtk_combo_box_get_model (user_combo);
@@ -2275,6 +2276,20 @@ start_session (void)
         start_authentication (lightdm_greeter_get_authentication_user (greeter));
     }
     g_free (session);
+}
+
+void
+password_icon_press_cb (GtkEntry *entry, GtkEntryIconPosition pos, GdkEvent *event, gpointer user_data);
+G_MODULE_EXPORT
+void
+password_icon_press_cb (GtkEntry *entry, GtkEntryIconPosition pos, GdkEvent *event, gpointer user_data)
+{
+    if (pos != GTK_ENTRY_ICON_SECONDARY)
+        return;
+    gboolean visible = gtk_entry_get_visibility (entry);
+    gtk_entry_set_visibility (entry, !visible);
+    gtk_entry_set_icon_from_icon_name (entry, GTK_ENTRY_ICON_SECONDARY,
+        visible ? "eye-open-negative-filled-symbolic" : "eye-not-looking-symbolic");
 }
 
 gboolean

--- a/src/lightdm-gtk-greeter.glade
+++ b/src/lightdm-gtk-greeter.glade
@@ -458,10 +458,12 @@
                     <property name="visibility">False</property>
                     <property name="invisible_char">•</property>
                     <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
+                    <property name="secondary_icon_name">eye-open-negative-filled-symbolic</property>
+                    <property name="secondary_icon_activatable">True</property>
                     <property name="placeholder_text" translatable="yes">Enter your password</property>
                     <signal name="activate" handler="login_cb" swapped="no"/>
                     <signal name="key-press-event" handler="password_key_press_cb" swapped="no"/>
+                    <signal name="icon-press" handler="password_icon_press_cb" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>


### PR DESCRIPTION
## Problem

There is currently no way to verify what has been typed in the password field before pressing Enter. On a mistyped password the user only finds out after the failed authentication delay, which is especially frustrating on touch keyboards or with complex passwords.

## Solution

Add a clickable eye icon (GTK secondary icon) to the password `GtkEntry` that toggles the text between hidden and visible. This is the standard pattern used by most modern login dialogs (GNOME, KDE, etc.) and is built entirely on existing GTK+ entry icon APIs — no new dependencies.

## Changes

**`src/lightdm-gtk-greeter.glade`**
- Set `secondary_icon_name` to `view-reveal-symbolic`
- Enable `secondary_icon_activatable`
- Wire `icon-press` signal to `password_icon_press_cb`

**`src/lightdm-gtk-greeter.c`**
- Add `password_icon_press_cb`: toggles `gtk_entry_set_visibility` and swaps the icon between `view-reveal-symbolic` and `view-conceal-symbolic`
- Reset icon and visibility when the user selector changes (so switching users always starts with a hidden field)

## Testing

Tested on Xubuntu with `lightdm-gtk-greeter 2.0.9` and the `elementary-xfce` icon theme. The eye icon appears, toggles correctly on click, and resets when switching users.