### PR TITLE
build: Remove `G_GNUC_CONST` from get_type declarations

### DIFF
--- a/src/greeterbackground.h
+++ b/src/greeterbackground.h
@@ -42,7 +42,7 @@ typedef enum
 typedef struct _GreeterBackground           GreeterBackground;
 typedef struct _GreeterBackgroundClass      GreeterBackgroundClass;
 
-GType greeter_background_get_type(void) G_GNUC_CONST;
+GType greeter_background_get_type(void);
 
 GreeterBackground* greeter_background_new           (GtkWidget* child);
 void greeter_background_set_active_monitor_config   (GreeterBackground* background,

--- a/src/greetermenubar.h
+++ b/src/greetermenubar.h
@@ -35,7 +35,7 @@ struct _GreeterMenuBarClass
     GtkMenuBarClass parent_class;
 };
 
-GType greeter_menu_bar_get_type(void) G_GNUC_CONST;
+GType greeter_menu_bar_get_type(void);
 GtkWidget *greeter_menu_bar_new(void);
 
 G_END_DECLS


### PR DESCRIPTION
The get_type functions have global side effects, which makes them ineligible for the `G_GNUC_CONST` attribute.

See https://gitlab.gnome.org/GNOME/glib/-/commit/01682955 for further details.

Closes #207