### PR TITLE
build: Fix a -Wextra-semi-stmt warning

### DIFF
--- a/src/lightdm-gtk-greeter.c
+++ b/src/lightdm-gtk-greeter.c
@@ -2368,7 +2368,7 @@ menubar_key_press_cb (GtkWidget *widget, GdkEventKey *event, gpointer user_data)
         return TRUE;
     default:
         return FALSE;
-    };
+    }
 }
 
 gboolean


### PR DESCRIPTION
This PR fixes the following warning:

```
lightdm-gtk-greeter.c:2371:6: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
 2371 |     };
```