### PR TITLE
build: Fix a -Wunused-variable warning

### DIFF
--- a/src/greeteruserimage.c
+++ b/src/greeteruserimage.c
@@ -148,7 +148,7 @@ get_default_user_image_from_settings (void)
 static GdkPixbuf *
 get_default_user_image (void)
 {
-    GdkPixbuf *temp_image = NULL, *image = NULL;
+    GdkPixbuf *image = NULL;
     GError *error = NULL;
 
     /* If a file is set by preferences, it must be prioritized. */


### PR DESCRIPTION
This PR fixes the following warning:

```
greeteruserimage.c:151:16: warning: unused variable 'temp_image' [-Wunused-variable]
  151 |     GdkPixbuf *temp_image = NULL, *image = NULL;
      |                ^~~~~~~~~~
1 warning generated.
```